### PR TITLE
Added na.rm parameter for getMeth regions. 

### DIFF
--- a/R/BSseq_utils.R
+++ b/R/BSseq_utils.R
@@ -35,7 +35,8 @@ orderBSseq <- function(BSseq, seqOrder = NULL) {
 
 
 getMeth <- function(BSseq, regions = NULL, type = c("smooth", "raw"),
-                    what = c("perBase", "perRegion"), confint = FALSE, alpha = 0.95) {
+                    what = c("perBase", "perRegion"), confint = FALSE, alpha = 0.95,
+                    na.rm = TRUE) {
     p.conf <- function(p, n, alpha) {
         z <- abs(qnorm((1 - alpha)/2, mean = 0, sd = 1))
         upper <- (p + z^2/(2*n) + z*sqrt(  (p*(1-p) + z^2/(4*n)) / n)) /
@@ -96,12 +97,12 @@ getMeth <- function(BSseq, regions = NULL, type = c("smooth", "raw"),
     if(what == "perRegion") {
         if(type == "smooth") {
             out <- lapply(mmsplit, function(xx) {
-                colMeans(getBSseq(BSseq, "trans")(getBSseq(BSseq, "coef")[xx,,drop = FALSE]), na.rm = TRUE)
+                colMeans(getBSseq(BSseq, "trans")(getBSseq(BSseq, "coef")[xx,,drop = FALSE]), na.rm = na.rm)
             })
         }
         if(type == "raw") {
             out <- lapply(mmsplit, function(xx) {
-                colMeans(getBSseq(BSseq, "M")[xx,,drop = FALSE] / getBSseq(BSseq, "Cov")[xx,,drop = FALSE], na.rm = TRUE)
+                colMeans(getBSseq(BSseq, "M")[xx,,drop = FALSE] / getBSseq(BSseq, "Cov")[xx,,drop = FALSE], na.rm = na.rm)
             })
         }
         out <- do.call(rbind, out)

--- a/man/getMeth.Rd
+++ b/man/getMeth.Rd
@@ -8,7 +8,8 @@
 }
 \usage{
 getMeth(BSseq, regions = NULL, type = c("smooth", "raw"),
-  what = c("perBase", "perRegion"), confint = FALSE, alpha = 0.95)
+  what = c("perBase", "perRegion"), confint = FALSE, alpha = 0.95,
+  na.rm = TRUE)
 }
 \arguments{
   \item{BSseq}{An object of class \code{BSseq}.}
@@ -20,6 +21,7 @@ getMeth(BSseq, regions = NULL, type = c("smooth", "raw"),
     methylation estimates (see below).  This is only supported if
     \code{what} is equal to \code{perBase}.}
   \item{alpha}{alpha value for the confidence interval.}
+  \item{na.rm}{whether to ignore NA methylation values for region averages}
 }
 \note{
   A \code{BSseq} object needs to be smoothed by the function
@@ -44,7 +46,10 @@ getMeth(BSseq, regions = NULL, type = c("smooth", "raw"),
   corresponding to a genomic region (and each row of the matrix being a
   loci inside the region).  If \code{what = "perRegion"} the function
   returns a matrix, with each row corresponding to a region and
-  containing the average methylation level in that region.
+  containing the average methylation level in that region.  If
+  \code{na.rm = FALSE}, the average methylation level of regions is given
+  as NA if any CpG in the region has a coverage of 0 and therefore
+  methylation level of NA.
 }
 \references{
   A Agresti and B Coull.


### PR DESCRIPTION
If a given region contains CpGs with with coverage 0, they are currently excluded from the averaging of the methylation values in that region. This can be highly biased if CpGs in the region have different methylation values and are compared to samples with higher coverage. Now you get NA as return if `na.rm = FALSE` for those regions, so you can easily exclude them from analysis. In theory I would think that this might even be the default parameter, though I understand that we should not force it here for compatibility reasons.

Notes:
1. I am not sure whether the argument makes much sense for smoothed beta-values. I still included it from comparability
2. I have not that much experience in R-documentation, please check whether my documentation is correct (or do you use any framework like Roxygen for that?)
