### PR TITLE
Fix the BSseq class constructor Resolve https://github.com/hansenlab/bsseq/issues/80

### DIFF
--- a/R/BSseq-class.R
+++ b/R/BSseq-class.R
@@ -93,9 +93,6 @@ BSseq <- function(M = NULL, Cov = NULL, coef = NULL, se.coef = NULL,
         if (is.null(pData)) {
             # BSseq object will have no colnames.
             pData <- S4Vectors:::new_DataFrame(nrows = ncol(M))
-        } else {
-            # BSseq object will have 'sampleNames' as colnames.
-            pData <- DataFrame(row.names = sampleNames)
         }
     } else {
         if (is.null(pData)) {


### PR DESCRIPTION
This fix is for the case when `pData` is not `NULL` and `sampleNames` is `NULL`.