### PR TITLE
Don't checkDimnames when making SummarizedExperiment

### DIFF
--- a/R/combine.R
+++ b/R/combine.R
@@ -217,7 +217,9 @@ combineList <- function(x, ..., BACKEND = NULL) {
     se <- SummarizedExperiment(
         assays = ans_assays,
         rowRanges = ans_rowRanges,
-        colData = ans_colData)
+        colData = ans_colData,
+        checkDimnames = FALSE
+  )
     # TODO: Avoid validity check.
     .BSseq(se, parameters = ans_parameters, trans = ans_trans)
 }


### PR DESCRIPTION
We've been getting this error when using `bsseq::combine` on bsseq objects with different colnames:

```
Error in SummarizedExperiment(assays = ans_assays,rowRanges = ans_rowRanges,: 
the rownames and colnames of the supplied assay(s) must be NULL or 
identical to those of the RangedSummarizedExperiment object (or derivative) to construct
```

This patch remvoves the validity check so that the SummarizedExperiment object is created without error.