### PR TITLE
Switch to the latest tatami interface for the M/Cov validity check.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Imports:
     utils,
     HDF5Array (>= 1.19.11),
     rhdf5,
-    beachmat
+    beachmat (>= 2.23.2)
 Suggests:
     testthat,
     bsseqData,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,8 @@ Imports:
     Biostrings,
     utils,
     HDF5Array (>= 1.19.11),
-    rhdf5
+    rhdf5,
+    beachmat
 Suggests:
     testthat,
     bsseqData,
@@ -49,7 +50,6 @@ Suggests:
     doParallel,
     rtracklayer,
     BSgenome.Hsapiens.UCSC.hg38,
-    beachmat (>= 1.5.2),
     batchtools
 Collate:
     utils.R
@@ -82,6 +82,10 @@ VignetteBuilder: knitr
 URL: https://github.com/kasperdanielhansen/bsseq
 BugReports: https://github.com/kasperdanielhansen/bsseq/issues
 biocViews: DNAMethylation
-LinkingTo: Rcpp, beachmat
+LinkingTo:
+    Rcpp,
+    beachmat,
+    assorthead
+SystemRequirements: C++17
 NeedsCompilation: yes
 RoxygenNote: 7.1.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -85,7 +85,7 @@ biocViews: DNAMethylation
 LinkingTo:
     Rcpp,
     beachmat,
-    assorthead
+    assorthead (>= 1.1.4)
 SystemRequirements: C++17
 NeedsCompilation: yes
 RoxygenNote: 7.1.0

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -38,6 +38,7 @@ importMethodsFrom(GenomeInfoDb, "seqlengths", "seqlengths<-", "seqinfo",
                   "seqlevels<-", "sortSeqlevels")
 importFrom(GenomeInfoDb, "Seqinfo")
 importFrom(gtools, "combinations")
+importFrom(beachmat, initializeCpp)
 importFrom(Rcpp, sourceCpp)
 
 # NOTE: data.table has some NAMESPACE clashes with functions in Bioconductor,

--- a/R/BSseq-class.R
+++ b/R/BSseq-class.R
@@ -26,7 +26,7 @@
 
 .checkMandCov <- function(M, Cov) {
     msg <- NULL
-    validMsg(msg, .Call(cxx_check_M_and_Cov, M, Cov))
+    validMsg(msg, .Call(cxx_check_M_and_Cov, initializeCpp(M), initializeCpp(Cov), 1))
 }
 
 # TODO: Benchmark validity method

--- a/src/BSseq.h
+++ b/src/BSseq.h
@@ -8,7 +8,7 @@ extern "C" {
 
     // Validity checking.
 
-    SEXP check_M_and_Cov(SEXP, SEXP);
+    SEXP check_M_and_Cov(SEXP, SEXP, SEXP);
 }
 
 #endif

--- a/src/check_M_and_Cov.cpp
+++ b/src/check_M_and_Cov.cpp
@@ -15,7 +15,7 @@ SEXP check_M_and_Cov(SEXP M, SEXP Cov, SEXP nt) {
 
     Rtatami::BoundNumericPointer M_bound(M);
     const auto& M_bm = *(M_bound->ptr);
-    Rtatami::BoundNumericPointer Cov_bound(M);
+    Rtatami::BoundNumericPointer Cov_bound(Cov);
     const auto& Cov_bm = *(Cov_bound->ptr);
 
     // Get the dimensions of 'M' and 'Cov' and check these are compatible.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -9,7 +9,7 @@ extern "C" {
 
     static const R_CallMethodDef all_call_entries[] = {
         // Validity checking.
-        REGISTER(check_M_and_Cov, 2),
+        REGISTER(check_M_and_Cov, 3),
         {NULL, NULL, 0}
     };
 


### PR DESCRIPTION
Pretty much what it says on the tin; the idea is to move on from the old **beachmat** interface. Most changes should be self-explanatory, but you can also check out the discussion at const-ae/glmGamPoi#66. The parallelization isn't strictly necessary but I just threw it in as a bonus.